### PR TITLE
Site-specific exceptions

### DIFF
--- a/extension/css/common.css
+++ b/extension/css/common.css
@@ -30,10 +30,12 @@
 .ic-hidden:before  { content: '\e801'; } /* '' */
 .ic-pass:before    { content: '\e802'; } /* '' */
 .ic-domain:before  { content: '\e803'; } /* '' */
+.ic-domchange:before  { content: '\e803'; } /* '' */
 .ic-ok:before      { content: '\e804'; } /* '' */
 .ic-invalid:before { content: '\e805'; } /* '' */
 .ic-valid:before   { content: '\e806'; } /* '' */
 .ic-stealth:before { content: '\e807'; } /* '' */
+.ic-append:before { content: '\e807'; } /* '' */
 .ic-number:before  { content: '\e808'; } /* '' */
 .ic-name:before    { content: '\e809'; } /* '' */
 .ic-hint:before    { content: '\e810'; } /* '' */

--- a/extension/js/exception.class.js
+++ b/extension/js/exception.class.js
@@ -1,0 +1,47 @@
+(function () {
+    'use strict';
+
+    function guid() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (Math.random() * 16) | 0,
+                v = c === 'x' ? r : (r&0x3|0x8);
+            return v.toString(16);
+        });
+    }
+
+    function Exception(options) {
+        options = options || {};
+        this.id = guid();
+        this.type = 'exception';
+        this.domain = options.domain || '';
+        this.changeDomain = options.changeDomain || '';
+        this.append = options.append || '';
+    }
+
+    Exception.prototype = {
+        constructor: Exception,
+
+        save: function save(callback) {
+            var ob = {};
+            ob[this.id] = JSON.stringify(this);
+            chrome.storage.sync.set(ob, callback);
+        }
+    };
+
+    Exception.retreive = function retreive(id, callback) {
+        chrome.storage.sync.get(id, function (items) {
+            callback(Object.keys(items).map(function (key) {
+                var options = JSON.parse(items[key]),
+                    exception = items[key] = Object.create(Password.prototype);
+                Object.keys(options).forEach(function (key) {
+                    exception[key] = options[key];
+                });
+                return exception;
+            }).filter(function (p){
+                return p.type === 'exception';
+            }));
+        });
+    };
+
+    window.Exception = Exception;
+})();

--- a/extension/js/options.js
+++ b/extension/js/options.js
@@ -26,13 +26,13 @@
         );
     }
 
-    function addException(exception) {
-        $('#saved_exceptions tbody').append(
+    function addSiteProfile(profile) {
+        $('#saved_site_profiles tbody').append(
             '<tr>' +
-                '<td>' + exception.domain + '</td>' +
-                '<td>' + exception.changeDomain + '</td>' +
-                '<td>' + exception.append + '</td>' +
-                '<td><button class="remove" data-id="' + exception.id + '">Remove</button></td>' +
+                '<td>' + profile.domain + '</td>' +
+                '<td>' + profile.changeDomain + '</td>' +
+                '<td>' + profile.append + '</td>' +
+                '<td><button class="remove" data-id="' + profile.id + '">Remove</button></td>' +
             '</tr>'
         );
     }
@@ -91,15 +91,15 @@
             });
         });
 
-        $('#newException').on('submit', function (event) {
+        $('#newSiteProfile').on('submit', function (event) {
             event.preventDefault();
-            var exception = new Exception({
+            var profile = new SiteProfile({
                 domain: this.domain.value,
                 changeDomain: this.changeDomain.value,
                 append: this.append.value,
             });
-            exception.save(function () {
-                addException(exception);
+            profile.save(function () {
+                addSiteProfile(profile);
             });
         });
 
@@ -110,7 +110,7 @@
             });
         });
 
-        $('#saved_exceptions').on('click', '.remove', function () {
+        $('#saved_site_profiles').on('click', '.remove', function () {
             var $this = $(this);
             chrome.storage.sync.remove($this.data('id'), function () {
                 $this.parents('tr').remove();
@@ -121,8 +121,8 @@
             items.forEach(addPassword);
         });
 
-        Exception.retreive(null, function (items) {
-            items.forEach(addException);
+        SiteProfile.retreive(null, function (items) {
+            items.forEach(addSiteProfile);
         });
     });
 })(Zepto);

--- a/extension/js/options.js
+++ b/extension/js/options.js
@@ -26,6 +26,17 @@
         );
     }
 
+    function addException(exception) {
+        $('#saved_exceptions tbody').append(
+            '<tr>' +
+                '<td>' + exception.domain + '</td>' +
+                '<td>' + exception.changeDomain + '</td>' +
+                '<td>' + exception.append + '</td>' +
+                '<td><button class="remove" data-id="' + exception.id + '">Remove</button></td>' +
+            '</tr>'
+        );
+    }
+
     $(function () {
 
         $('body').on('focus', '.fld input', function () {
@@ -80,7 +91,26 @@
             });
         });
 
+        $('#newException').on('submit', function (event) {
+            event.preventDefault();
+            var exception = new Exception({
+                domain: this.domain.value,
+                changeDomain: this.changeDomain.value,
+                append: this.append.value,
+            });
+            exception.save(function () {
+                addException(exception);
+            });
+        });
+
         $('#saved_passwords').on('click', '.remove', function () {
+            var $this = $(this);
+            chrome.storage.sync.remove($this.data('id'), function () {
+                $this.parents('tr').remove();
+            });
+        });
+
+        $('#saved_exceptions').on('click', '.remove', function () {
             var $this = $(this);
             chrome.storage.sync.remove($this.data('id'), function () {
                 $this.parents('tr').remove();
@@ -91,5 +121,8 @@
             items.forEach(addPassword);
         });
 
+        Exception.retreive(null, function (items) {
+            items.forEach(addException);
+        });
     });
 })(Zepto);

--- a/extension/js/password.class.js
+++ b/extension/js/password.class.js
@@ -76,6 +76,8 @@
                     pass.password = chrome.extension.getBackgroundPage().passwords[pass.id];
                 }
                 return pass;
+            }).filter(function (p){
+                return Object.keys(Password.generators).indexOf(p.type) >= 0;
             }));
         });
     };

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,13 +1,13 @@
 (function ($) {
     'use strict';
     var selectedPass;
-    var siteException;
+    var siteProfile;
 
     function updateDomain() {
         var domain = $('#domain');
         var value = Password.parseUrl(domain.attr('data-originalurl'), $('#trimdomain')[0].checked);
-        if (siteException && siteException.changeDomain) {
-            value = siteException.changeDomain;
+        if (siteProfile && siteProfile.changeDomain) {
+            value = siteProfile.changeDomain;
         }
         domain.val(value);
     }
@@ -31,8 +31,8 @@
                     $('#domain').val(),
                     $('#trimdomain')[0].checked
                 );
-                if (siteException && siteException.append) {
-                    password = password + siteException.append;
+                if (siteProfile && siteProfile.append) {
+                    password = password + siteProfile.append;
                 }
                 $('#generated_password').val(password);
                 chrome.tabs.getSelected(function (currentTab) {
@@ -73,10 +73,10 @@
             }
         });
 
-        Exception.retreive(null, function (excs) {
-            excs.forEach(function (exc, i) {
-                if (exc.domain === $('#domain').val()) {
-                    siteException = exc;
+        SiteProfile.retreive(null, function (profiles) {
+            profiles.forEach(function (profile, i) {
+                if (profile.domain === $('#domain').val()) {
+                    siteProfile = profile;
                     updateDomain();
                 }
             });

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -74,8 +74,9 @@
         });
 
         SiteProfile.retreive(null, function (profiles) {
-            profiles.forEach(function (profile, i) {
-                if (profile.domain === $('#domain').val()) {
+            var domain = $('#domain').val();
+            profiles.some(function (profile, i) {
+                if (profile.domain === domain) {
                     siteProfile = profile;
                     updateDomain();
                 }

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,10 +1,15 @@
 (function ($) {
     'use strict';
     var selectedPass;
+    var siteException;
 
     function updateDomain() {
         var domain = $('#domain');
-        domain.val(Password.parseUrl(domain.attr('data-originalurl'), $('#trimdomain')[0].checked));
+        var value = Password.parseUrl(domain.attr('data-originalurl'), $('#trimdomain')[0].checked);
+        if (siteException && siteException.changeDomain) {
+            value = siteException.changeDomain;
+        }
+        domain.val(value);
     }
 
     function setupPassword() {
@@ -26,6 +31,9 @@
                     $('#domain').val(),
                     $('#trimdomain')[0].checked
                 );
+                if (siteException && siteException.append) {
+                    password = password + siteException.append;
+                }
                 $('#generated_password').val(password);
                 chrome.tabs.getSelected(function (currentTab) {
                     chrome.tabs.sendRequest(currentTab.id, {
@@ -63,6 +71,15 @@
                     '</li>');
                 });
             }
+        });
+
+        Exception.retreive(null, function (excs) {
+            excs.forEach(function (exc, i) {
+                if (exc.domain === $('#domain').val()) {
+                    siteException = exc;
+                    updateDomain();
+                }
+            });
         });
 
         $passwordList.on('mouseenter', 'li', function () {

--- a/extension/js/site_profile.class.js
+++ b/extension/js/site_profile.class.js
@@ -9,17 +9,17 @@
         });
     }
 
-    function Exception(options) {
+    function SiteProfile(options) {
         options = options || {};
         this.id = guid();
-        this.type = 'exception';
+        this.type = 'site_profile';
         this.domain = options.domain || '';
         this.changeDomain = options.changeDomain || '';
         this.append = options.append || '';
     }
 
-    Exception.prototype = {
-        constructor: Exception,
+    SiteProfile.prototype = {
+        constructor: SiteProfile,
 
         save: function save(callback) {
             var ob = {};
@@ -28,20 +28,15 @@
         }
     };
 
-    Exception.retreive = function retreive(id, callback) {
+    SiteProfile.retreive = function retreive(id, callback) {
         chrome.storage.sync.get(id, function (items) {
             callback(Object.keys(items).map(function (key) {
-                var options = JSON.parse(items[key]),
-                    exception = items[key] = Object.create(Password.prototype);
-                Object.keys(options).forEach(function (key) {
-                    exception[key] = options[key];
-                });
-                return exception;
+                return new SiteProfile(JSON.parse(items[key]));
             }).filter(function (p){
-                return p.type === 'exception';
+                return p.type === 'site_profile';
             }));
         });
     };
 
-    window.Exception = Exception;
+    window.SiteProfile = SiteProfile;
 })();

--- a/extension/options.html
+++ b/extension/options.html
@@ -121,8 +121,8 @@
     </section>
 
     <section class="panel">
-        <h2>Site exceptions</h2>
-        <table id="saved_exceptions">
+        <h2>Site profiles</h2>
+        <table id="saved_site_profiles">
             <thead>
                 <tr>
                     <th>Domain</th>
@@ -136,14 +136,14 @@
     </section>
 
     <section class="panel">
-        <form id="newException">
-            <h2>Create new site exception</h2>
+        <form id="newSiteProfile">
+            <h2>Create new site profile</h2>
 
             <label class="fld fld-input">
                 <i class="ic ic-domain"></i>
                 <input id="domain" type="text" value="" placeholder="Domain" autofocus="autofocus">
                 <p class="hint">
-                    Give the domain that this exception applies to.
+                    Give the domain that this profile applies to.
                 </p>
             </label>
 
@@ -151,7 +151,8 @@
                 <i class="ic ic-domchange"></i>
                 <input id="changeDomain" type="text" value="" placeholder="Change domain to">
                 <p class="hint">
-                    Enter a different domain here to change the domain that will be used for password calculation. (This setting is useful when a site uses the same login on multiple domains.)
+                    Enter a different domain here to change the domain that will be used for password calculation. 
+                    (This setting is useful when a site uses the same login on multiple domains.)
                 </p>
             </label>
 
@@ -164,7 +165,7 @@
                 </p>
             </label>
 
-            <button type="submit">Create new site exception</button>
+            <button type="submit">Create new site profile</button>
         </form>
 
     </section>
@@ -192,7 +193,7 @@
     <script src="bower_components/zepto/zepto.js"></script>
     <script src="js/bcrypt.js"></script>
     <script src="js/password.class.js"></script>
-    <script src="js/exception.class.js"></script>
+    <script src="js/site_profile.class.js"></script>
     <script src="js/options.js"></script>
 </body>
 </html>

--- a/extension/options.html
+++ b/extension/options.html
@@ -120,6 +120,55 @@
 
     </section>
 
+    <section class="panel">
+        <h2>Site exceptions</h2>
+        <table id="saved_exceptions">
+            <thead>
+                <tr>
+                    <th>Domain</th>
+                    <th>Change domain to</th>
+                    <th>Append string</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </section>
+
+    <section class="panel">
+        <form id="newException">
+            <h2>Create new site exception</h2>
+
+            <label class="fld fld-input">
+                <i class="ic ic-domain"></i>
+                <input id="domain" type="text" value="" placeholder="Domain" autofocus="autofocus">
+                <p class="hint">
+                    Give the domain that this exception applies to.
+                </p>
+            </label>
+
+            <label class="fld fld-input">
+                <i class="ic ic-domchange"></i>
+                <input id="changeDomain" type="text" value="" placeholder="Change domain to">
+                <p class="hint">
+                    Enter a different domain here to change the domain that will be used for password calculation. (This setting is useful when a site uses the same login on multiple domains.)
+                </p>
+            </label>
+
+            <label class="fld fld-input">
+                <i class="ic ic-append"></i>
+                <input id="append" type="text" value="" placeholder="Append string">
+                <p class="hint">
+                    This string will be appended to the calculated password.
+                    (This setting is useful when a site requires passwords to contain special characters.)
+                </p>
+            </label>
+
+            <button type="submit">Create new site exception</button>
+        </form>
+
+    </section>
+
     <section class="panel" id="about">
         <p><small>
             Thanks to all the supporters and all those whom have reported issues. Your
@@ -143,6 +192,7 @@
     <script src="bower_components/zepto/zepto.js"></script>
     <script src="js/bcrypt.js"></script>
     <script src="js/password.class.js"></script>
+    <script src="js/exception.class.js"></script>
     <script src="js/options.js"></script>
 </body>
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -36,7 +36,7 @@
         <script src="js/bcrypt.js"></script>
         <script src="js/supergenpass.js"></script>
         <script src="js/password.class.js"></script>
-        <script src="js/exception.class.js"></script>
+        <script src="js/site_profile.class.js"></script>
         <script src="js/popup.js"></script>
     </body>
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -36,6 +36,7 @@
         <script src="js/bcrypt.js"></script>
         <script src="js/supergenpass.js"></script>
         <script src="js/password.class.js"></script>
+        <script src="js/exception.class.js"></script>
         <script src="js/popup.js"></script>
     </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -17,7 +17,9 @@
         <script src="../extension/js/bcrypt.js"></script>
         <script src="../extension/js/supergenpass.js"></script>
         <script src="../extension/js/password.class.js"></script>
+        <script src="../extension/js/site_profile.class.js"></script>
         <script src="password.class.test.js"></script>
+        <script src="site_profile.class.test.js"></script>
 
         <script>
             mocha.checkLeaks();

--- a/test/site_profile.class.test.js
+++ b/test/site_profile.class.test.js
@@ -1,0 +1,63 @@
+describe('SiteProfile Class', function () {
+    var profile;
+
+    beforeEach(function () {
+        profile = new SiteProfile();
+    });
+
+    describe('newing up', function () {
+
+        it('generates a new unique guid for every site profile', function () {
+            var i, iterations = 30, ids = [];
+
+            for (i = 0; i < iterations; ++i) {
+                profile = new SiteProfile();
+
+                profile.id.length.should.equal(36)
+
+                ids.push(profile.id);
+            }
+
+            // Make sure all GUIDs created were unique.
+            ids.filter(function(item, i){return ids.indexOf(item) === i;}).length
+                .should.equal(iterations);
+
+        });
+
+        it('sets the type to site_profile by default', function () {
+
+            profile.type.should.equal('site_profile');
+
+            profile = new SiteProfile({ type: 'foo' });
+
+            profile.type.should.equal('site_profile');
+
+        });
+
+        it('sets the domain from options defaulting to ""', function () {
+
+            (new SiteProfile({ })).domain.should.equal('');
+            (new SiteProfile({ domain: 'foo' })).domain.should.equal('foo');
+            (new SiteProfile({ domain: 'example.com' })).domain.should.equal('example.com');
+
+        });
+
+        it('sets the change domain value from options defaulting to ""', function () {
+
+            (new SiteProfile({ })).changeDomain.should.equal('');
+            (new SiteProfile({ changeDomain: 'foo' })).changeDomain.should.equal('foo');
+            (new SiteProfile({ changeDomain: 'example.com' })).changeDomain.should.equal('example.com');
+
+        });
+
+        it('sets the append value from options defaulting to ""', function () {
+
+            (new SiteProfile({ })).append.should.equal('');
+            (new SiteProfile({ append: 'foo' })).append.should.equal('foo');
+            (new SiteProfile({ append: '$' })).append.should.equal('$');
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
I have been using LP on lots of pages for a few years I really like it. However some sites cause me a lot of trouble. This is mostly because one of the following reasons:

  * The site wants to have a special character in the password. Here I have to use LP and manually append a special character.
  * The site uses the same login for multiple domains. Here I have to remember the *main domain* and change all others to it.
  * The site changes the domain (e.g. from .com to .org). Normal users do not notice this but for me the password changes.

All of these problems can be *fixed* by memorizing all those exceptions but I think the extension could store them for me.

I implemented site-specific exceptions that let you configure whether the domain should be changed or what characters should be appended.

I tried to stick to the programming style of the project but please tell me if you want me to change something.