### PR TITLE
Fixed test case

### DIFF
--- a/test/password.class.test.js
+++ b/test/password.class.test.js
@@ -42,9 +42,9 @@ describe('Password Class', function () {
 
         });
 
-        it('sets the name from options, defaulting to "My Password"', function () {
+        it('sets the name from options, defaulting to "Default"', function () {
 
-            (new Password({ })).name.should.equal('My Password');
+            (new Password({ })).name.should.equal('Default');
             (new Password({ name: 'foo' })).name.should.equal('foo');
             (new Password({ name: 'MyPass' })).name.should.equal('MyPass');
 


### PR DESCRIPTION
I found this while adding my test cases:
```
sets the name from options, defaulting to "My Password" ‣
AssertionError: expected 'Default' to equal 'My Password'
```
This is a simple case of changing a value and forgetting to change the test case.