### PR TITLE
Only positive maxLength should truncate passwords

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -44,6 +44,6 @@ chrome.extension.onRequest.addListener(function (request, sender) {
             }
         }
     } else if (el.tagName === 'INPUT' && el.type === 'password') {
-        el.value = password.substr(0, el.maxLength || password.length);
+        el.value = password.substr(0, Math.max(el.maxLength, 0) || password.length);
     }
 });


### PR DESCRIPTION
This allows handles negative maxLength in password inputs.

Currently inputs with a negative `maxLength` will have it's value set to an empty string.

Specifying a negative maxLength should result in the [default behavior](https://developer.mozilla.org/en/docs/Web/HTML/Element/input), which is to allow an unlimited number of characters, the full password in other words.

By limiting `maxLength` to a minimum of 0, the entire password will be used for values of `maxLength` less than or equal to 0, while values above 0 use the first `maxLength` characters of the password.